### PR TITLE
SAS-9 Prevent React Native error from appearing on sign up page, misc. fixes/formatting

### DIFF
--- a/mobile/navigation/AuthProvider.js
+++ b/mobile/navigation/AuthProvider.js
@@ -1,7 +1,7 @@
 import React, { createContext, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { initializeApp } from 'firebase/app';
-import { getAuth, signInWithEmailAndPassword, sendPasswordResetEmail, signOut } from 'firebase/auth';
+import { createUserWithEmailAndPassword, getAuth, signInWithEmailAndPassword, sendPasswordResetEmail, signOut } from 'firebase/auth';
 
 import {
     DefaultTheme as NavigationDefaultTheme,
@@ -62,7 +62,7 @@ export const AuthProvider = ({ children }) => {
 
     const setToken = async (user) => {
         try {
-            await AsyncStorage.setItem(key = 'userData', value = JSON.stringify(user));
+            await AsyncStorage.setItem('userData', JSON.stringify(user));
         } catch (error) {
             console.log('[AuthProvider] setToken() failed: ', error);
         }
@@ -108,8 +108,8 @@ export const AuthProvider = ({ children }) => {
                                     setUserId(userCredential.user.uid);
                                 })
                                 .catch((error) => {
-                                    var errorCode = error.code;
-                                    var errorMessage = error.message;
+                                    const errorCode = error.code;
+                                    const errorMessage = error.message;
                                     setAuthError(errorMessage);
                                     // console.log("Error signing in...", errorCode, errorMessage);
                                 });

--- a/mobile/screens/Authentication/ForgotPasswordScreen.js
+++ b/mobile/screens/Authentication/ForgotPasswordScreen.js
@@ -8,10 +8,10 @@ import i18n from '../../translations/i18n';
 
 const ForgotPasswordScreen = ({navigation}) => {
     const {
-        authStatus, 
-        setAuthStatus, 
-        authError, 
-        setAuthError, 
+        authStatus,
+        setAuthStatus,
+        authError,
+        setAuthError,
         resetPassword
     } = useContext(AuthContext);
     const [email, setEmail] = useState();
@@ -23,7 +23,7 @@ const ForgotPasswordScreen = ({navigation}) => {
 
     return (
         <View style={styles.container}>
-            <FormInput 
+            <FormInput
                 labelValue="Email"
                 placeholderText={i18n.t('authentication.email')}
                 iconType="user"
@@ -31,13 +31,13 @@ const ForgotPasswordScreen = ({navigation}) => {
                 keyboardType="email-address"
                 value={email}
                 onChangeText={(inEmail) => {setEmail(inEmail)}} />
-            <FormButton 
+            <FormButton
                 btnTitle={i18n.t('authentication.resetPassword')}
                 isHighlight={true}
                 onPress={ () => resetPassword(email) } />
-            { authError ? 
-            <Text style={[styles.centerItems, styles.errTextSyle]}>{authError}</Text> :
-            <Text style={[styles.centerItems, styles.statusTextSyle]}>{authStatus}</Text> }
+            { authError ?
+            <Text style={[styles.centerItems, styles.errTextStyle]}>{authError}</Text> :
+            <Text style={[styles.centerItems, styles.statusTextStyle]}>{authStatus}</Text> }
         </View>
     )
 }
@@ -53,10 +53,10 @@ const styles = StyleSheet.create({
         alignItems: 'center',
         margin: 10,
     },
-    statusTextSyle: {
+    statusTextStyle: {
         color: 'green'
     },
-    errTextSyle: {
+    errTextStyle: {
         color: 'red'
     }
 })

--- a/mobile/screens/Authentication/SignupScreen.js
+++ b/mobile/screens/Authentication/SignupScreen.js
@@ -31,13 +31,13 @@ const SignupScreen = ({navigation}) => {
     const [showDateTimePicker, setShowDateTimePicker] = useState(false);
     const handleDobPicker = (event, selectedDate) => {
         const currentDate = selectedDate || date
-        currentDateString = JSON.stringify(currentDate).slice(1).split('T')[0].split('-').join('/')
+        const currentDateString = JSON.stringify(currentDate).slice(1).split('T')[0].split('-').join('/')
         setInUserData({...inUserData, dob: currentDateString})
         setShowDateTimePicker( Platform.OS === 'ios' )
         setDate(currentDate)
     };
-    
-    handleConfirmPassword = (inConfirmPassword) => {
+
+    const handleConfirmPassword = (inConfirmPassword) => {
         // let inConfirmPassword = inConfirmPasswordEvent.nativeEvent.text;
         let isEqual = false;
         if (inConfirmPassword !== inUserData.password) {
@@ -49,7 +49,7 @@ const SignupScreen = ({navigation}) => {
         setInUserData({...inUserData, confirmPassword: inConfirmPassword, isValidPassword: isEqual})
     }
 
-    handleSignUpClicked = () => {
+    const handleSignUpClicked = () => {
         if (inUserData.email==='') {
             setAuthError("Email cannot be empty")
             return
@@ -73,7 +73,7 @@ const SignupScreen = ({navigation}) => {
         if (!inUserData.isValidPassword) {
             return
         }
-        
+
         signup(inUserData.email, inUserData.password, inUserData.firstName, inUserData.lastName, inUserData.dob, inUserData.avgDaysPerPeriod)
     }
 
@@ -83,7 +83,7 @@ const SignupScreen = ({navigation}) => {
 
     return (
         <View>
-            <FormInput 
+            <FormInput
                 labelValue="Email"
                 placeholderText={i18n.t('authentication.email')}
                 isRequired={true}
@@ -95,7 +95,7 @@ const SignupScreen = ({navigation}) => {
                     setInUserData({...inUserData, email: inEmail})
                 }}
                 onFocus={()=>{ setShowDateTimePicker(false) }} />
-            <FormInput 
+            <FormInput
                 labelValue="Password"
                 placeholderText={i18n.t('authentication.password')}
                 isRequired={true}
@@ -108,7 +108,7 @@ const SignupScreen = ({navigation}) => {
                     setInUserData({...inUserData, password: inPassword})
                 }}
                 onFocus={()=>{ setShowDateTimePicker(false) }} />
-            <FormInput 
+            <FormInput
                 labelValue="Confirm Password"
                 placeholderText={i18n.t('authentication.confirmPassword')}
                 isRequired={true}
@@ -123,12 +123,12 @@ const SignupScreen = ({navigation}) => {
             {inUserData.isValidPassword ? null :
             // <Animatable.View animation="fadeInLeft" duration={500}>
             <View>
-                <Text style={[styles.centerItems, styles.errTextSyle]}>Password does not match</Text>
+                <Text style={[styles.centerItems, styles.errTextStyle]}>Password does not match</Text>
             {/* </Animatable.View> */}
             </View>
             }
 
-            <FormInput 
+            <FormInput
                 labelValue="First Name"
                 placeholderText={i18n.t('authentication.firstName')}
                 isRequired={true}
@@ -139,7 +139,7 @@ const SignupScreen = ({navigation}) => {
                     setInUserData({...inUserData, firstName: inFirstName})
                 }}
                 onFocus={()=>{ setShowDateTimePicker(false) }} />
-            <FormInput 
+            <FormInput
                 labelValue="Last Name"
                 placeholderText={i18n.t('authentication.lastName')}
                 isRequired={true}
@@ -165,11 +165,11 @@ const SignupScreen = ({navigation}) => {
                     display="spinner"
                     timeZoneOffsetInMinutes={-60*24}
                     maximumDate={new Date()}
-                    onChange={handleDobPicker} 
+                    onChange={handleDobPicker}
                 />
             : null }
-            
-            <FormInput 
+
+            <FormInput
                 labelValue=""
                 placeholderText={i18n.t('authentication.avgPeriodDays')}
                 value={ inUserData.avgDaysPerPeriod }
@@ -188,16 +188,16 @@ const SignupScreen = ({navigation}) => {
             {authError ?
             // <Animatable.View animation="fadeInLeft" duration={500}>
             <View>
-                <Text style={[styles.centerItems, styles.errTextSyle]}>{authError}</Text>
+                <Text style={[styles.centerItems, styles.errTextStyle]}>{typeof(authError) === 'object' ? JSON.stringify(authError) : authError}</Text>
             </View>
             // </Animatable.View>
             : null}
 
             <Text style={styles.centerItems}>
-                By signing up, you agree to our 
-                <Text style={styles.underlineStyle} onPress={()=>Linking.openURL('https://google.com')}> Terms of Service </Text> 
-                and 
-                <Text style={styles.underlineStyle} onPress={()=>Linking.openURL('https://apple.com')}> Privacy Policy</Text>
+                By signing up, you agree to our
+                <Text style={styles.underlineStyle} onPress={()=>Linking.openURL('https://google.com')}>Terms of Service</Text>
+                and
+                <Text style={styles.underlineStyle} onPress={()=>Linking.openURL('https://apple.com')}>Privacy Policy</Text>
             </Text>
         </View>
     )
@@ -220,7 +220,6 @@ const styles = StyleSheet.create({
         backgroundColor: "white",
         borderRadius: 20,
         padding: 35,
-        alignItems: "center",
         shadowColor: "#000",
         shadowOffset: {
             width: 0,
@@ -236,7 +235,7 @@ const styles = StyleSheet.create({
     dobTextStyle: {
         color: 'black'
     },
-    errTextSyle: {
+    errTextStyle: {
         color: 'red'
     }
 })


### PR DESCRIPTION
This change prevents the React error message seen below from appearing while trying to sign up. The error messages that appear are still not elegant (e.g. the user might see a JSON string as an error message), but at least they don't crash the app. This change also fixes some random other issues:

- "Syle" -> "Style" typo
- A few uninitialized variables
- Removes named arguments, which don't exist in JS
- Random spaces on the ends of lines

![IMG_7687](https://user-images.githubusercontent.com/29609814/221425367-a7b94a27-b0cf-4d5f-a6f9-0e107b66e9d4.PNG)
