### PR TITLE
SAS-8: Tailwind Theme to Match Color Palette in Figma and Enable JIT Mode

### DIFF
--- a/mobile/tailwind.config.js
+++ b/mobile/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  // files where tailwind can be used (feel free to add more as needed)
   content: [
     "./assets/**/*.js",
     "./components/**/*.js",
@@ -9,8 +10,31 @@ module.exports = {
     "./translations/**/*.js",
     "./App.js",
 ],
+  // jit (just-in-time compilation) mode enables CSS functions like calc() to be used for dynamic styling
+  mode: 'jit',
+
+  // theme is used to define the colors, fonts, and other styles that are used throughout the app
+  // example: <View className="bg-teal border-2 border-salmon"> <-- teal and salmon will map to the colors values defined below
   theme: {
+    colors: {
+      'gray': '#D1D5DB',
+      'offwhite': '#FEFFF4',
+      'lavenderlight': '#DDD6F6',
+      'lavender': '#C0B3F1',
+      'salmon': '#ff7f73',
+      'teal': '#00394E',
+      'turquoise': '#005C6A',
+      'seafoam': '#5B9F8F',
+      'greydark': '#272727',
+    },
     extend: {},
   },
+
+  // plugins are general addons to extend tailwind
   plugins: [],
+    // safelist was added because some of the theme colors were not working, so adding this pattern ensures they will work across all files
+    safelist: [{
+      pattern: /(bg|text|border)-(gray|offwhite|lavenderlight|lavender|salmon|teal|turquoise|seafoam|greydark)/
+    }
+  ]
 }


### PR DESCRIPTION
This PR adds the colors from the Figma Hi-Fi color palette to tailwind.config.js so all files using tailwind styling can access these consistent colors. Also enables Just-In-Time compilation mode for tailwind allowing for CSS expressions like `calc()` calls and a safelist to prevent issues with certain colors not rendering.