### PR TITLE
[SAS-20] tailwind theme colors no longer overwrite existing colors

### DIFF
--- a/mobile/tailwind.config.js
+++ b/mobile/tailwind.config.js
@@ -16,18 +16,19 @@ module.exports = {
   // theme is used to define the colors, fonts, and other styles that are used throughout the app
   // example: <View className="bg-teal border-2 border-salmon"> <-- teal and salmon will map to the colors values defined below
   theme: {
-    colors: {
-      'gray': '#D1D5DB',
-      'offwhite': '#FEFFF4',
-      'lavenderlight': '#DDD6F6',
-      'lavender': '#C0B3F1',
-      'salmon': '#ff7f73',
-      'teal': '#00394E',
-      'turquoise': '#005C6A',
-      'seafoam': '#5B9F8F',
-      'greydark': '#272727',
-    },
-    extend: {},
+    extend: {
+      colors: {
+        'gray': '#D1D5DB',
+        'offwhite': '#FEFFF4',
+        'lavenderlight': '#DDD6F6',
+        'lavender': '#C0B3F1',
+        'salmon': '#ff7f73',
+        'teal': '#00394E',
+        'turquoise': '#005C6A',
+        'seafoam': '#5B9F8F',
+        'greydark': '#272727',
+      }
+    }
   },
 
   // plugins are general addons to extend tailwind


### PR DESCRIPTION
@vitdoan noticed that the tailwind.config.js file was not configured correctly. The colors should have been added to the `extend` object in the theme object, but I had put them directly into their own object, overwriting all of the existing colors with our custom ones. Our new custom colors and the existing default tailwind colors should work now.