### PR TITLE
fix: setting background on homepage to correct color #FEFFF4

### DIFF
--- a/mobile/screens/HomeScreen.js
+++ b/mobile/screens/HomeScreen.js
@@ -187,7 +187,7 @@ const HomeScreen = () => {
     if (isLoading) {
         console.log('[HomeScreen] loading...');
         return (
-            <SafeAreaView className="flex-1">
+            <SafeAreaView className="bg-offwhite flex-1">
                 <ScrollView
                     refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
                 >
@@ -210,7 +210,7 @@ const HomeScreen = () => {
     }
 
     return (
-        <SafeAreaView className="flex-1">
+        <SafeAreaView className="bg-offwhite flex-1">
             <ScrollView
                 refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
             >


### PR DESCRIPTION
This tiny merge request just changes the background of the home page to match the background on the Figma, #FEFF4.

Previously, no background was specified, so some default was being used.